### PR TITLE
remove import Network.Endian

### DIFF
--- a/source/Network/Stun/MappedAddress.hs
+++ b/source/Network/Stun/MappedAddress.hs
@@ -5,7 +5,6 @@ import Control.Monad
 import Data.Bits
 import Data.Serialize
 import Data.Word
-import Network.Endian
 import Network.Socket
 import Network.Stun.Base
 


### PR DESCRIPTION
`Network.Socket` now exports `htonl` causing an ambiguity.

Would also suggest version bump on hackage.
